### PR TITLE
Replace picocolors with nanocolors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "esbuild": "^0.13.3",
         "fetch-repo-dir": "^1.0.4",
         "fs-extra": "^10.0.0",
-        "picocolors": "^0.1.0",
+        "nanocolors": "^0.2.12",
         "prompts": "^2.4.1",
         "sade": "^1.7.4",
         "uvu": "^0.5.1"
@@ -508,6 +508,12 @@
       "integrity": "sha512-oi1b3MfbyGa7FJMP9GmLTttni5JoICpYBRlq+x5V16fZbLsnL9N3wFqqIm/nIG43FjUFkFh9Epzp/kzUGUnJxQ==",
       "dev": true
     },
+    "node_modules/nanocolors": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/nanocolors/-/nanocolors-0.2.12.tgz",
+      "integrity": "sha512-SFNdALvzW+rVlzqexid6epYdt8H9Zol7xDoQarioEFcFN0JHo4CYNztAxmtfgGTVRCmFlEOqqhBpoFGKqSAMug==",
+      "dev": true
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -521,12 +527,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
-    },
-    "node_modules/picocolors": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.1.0.tgz",
-      "integrity": "sha512-W+3MFREUEjPt0MnYaR51VkLw8tY8UubrLOqcBmaQocZhM34hQhjg50FQ0c6f0UldPlecieoqUqI6ToM/dNblDw==",
       "dev": true
     },
     "node_modules/prompts": {
@@ -1025,6 +1025,12 @@
       "integrity": "sha512-oi1b3MfbyGa7FJMP9GmLTttni5JoICpYBRlq+x5V16fZbLsnL9N3wFqqIm/nIG43FjUFkFh9Epzp/kzUGUnJxQ==",
       "dev": true
     },
+    "nanocolors": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/nanocolors/-/nanocolors-0.2.12.tgz",
+      "integrity": "sha512-SFNdALvzW+rVlzqexid6epYdt8H9Zol7xDoQarioEFcFN0JHo4CYNztAxmtfgGTVRCmFlEOqqhBpoFGKqSAMug==",
+      "dev": true
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -1038,12 +1044,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
-    },
-    "picocolors": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.1.0.tgz",
-      "integrity": "sha512-W+3MFREUEjPt0MnYaR51VkLw8tY8UubrLOqcBmaQocZhM34hQhjg50FQ0c6f0UldPlecieoqUqI6ToM/dNblDw==",
       "dev": true
     },
     "prompts": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "esbuild": "^0.13.3",
     "fetch-repo-dir": "^1.0.4",
     "fs-extra": "^10.0.0",
-    "picocolors": "^0.1.0",
+    "nanocolors": "^0.2.12",
     "prompts": "^2.4.1",
     "sade": "^1.7.4",
     "uvu": "^0.5.1"

--- a/src/banner.js
+++ b/src/banner.js
@@ -1,4 +1,4 @@
-import { red, green } from 'picocolors';
+import { red, green } from 'nanocolors';
 
 export function showMalinaBanner(){
     console.log('');

--- a/src/malina.js
+++ b/src/malina.js
@@ -6,7 +6,7 @@ import {getAppName,getTemplateRepo} from './prompts';
 import {showMalinaBanner} from './banner';
 import {loadTemplate,installDependencies} from './files';
 import {spinner} from './spinner';
-import { bold, italic, yellow, cyan } from 'picocolors';
+import { bold, italic, yellow, cyan } from 'nanocolors';
 
 const cli = sade('malina [name]', true);
 

--- a/src/spinner.js
+++ b/src/spinner.js
@@ -1,4 +1,4 @@
-import { green, red, bold } from 'picocolors';
+import { green, red, bold } from 'nanocolors';
 
 const spin = [
     `[${green('   ')}]`,


### PR DESCRIPTION
In previous [PR](https://github.com/malinajs/create-malina-app/pull/1) I've replaced `chalk` with `picocolors` and... everything is broken now. (Fails when you try to do something more than just run it and close). Fortunately tests are not passed and this was not pushed to npm.

Sorry please ＞﹏＜